### PR TITLE
""Small"" improvements and refactors for `minecraft.rs`

### DIFF
--- a/src/minecraft.rs
+++ b/src/minecraft.rs
@@ -188,7 +188,7 @@ impl From<char> for FormatCode {
 
 impl Display for FormatCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <char as Display>::fmt(&self.0, f)
+        write!(f, "§{}", self.get())
     }
 }
 

--- a/src/minecraft.rs
+++ b/src/minecraft.rs
@@ -56,10 +56,10 @@ impl TryFrom<FormatCode> for Format {
                 $( $color_code:expr => $color:ident ),+ ;
                 $( $format_code:expr => $format:ident ),+ ;
             ) => {
-                match code.get() {
-                    $( $color_code => Ok(Self::Color(Color::$color)) ),+,
-                    $( $format_code => Ok(Self::$format) ),+,
-                    code => Err(Error::NoSuchFormatCode(code)),
+                match code {
+                    $( FormatCode($color_code) => Ok(Self::Color(Color::$color)) ),+,
+                    $( FormatCode($format_code) => Ok(Self::$format) ),+,
+                    FormatCode(code) => Err(Error::NoSuchFormatCode(code)),
                 }
             };
         }
@@ -135,7 +135,7 @@ impl From<Color> for ColorValue {
                 $color:ident => $code:expr, $name:expr, $fg:expr, $bg:expr
             );+ ; ) => {
                 match color {$(
-                    Color::$color => ColorValue::new($code.into(), $name, $fg, $bg)
+                    Color::$color => ColorValue::new(FormatCode::new($code), $name, $fg, $bg)
                 ),+}
             };
         }

--- a/src/minecraft.rs
+++ b/src/minecraft.rs
@@ -99,7 +99,7 @@ impl TryFrom<FormatCode> for Format {
         ///
         /// Codes that match `Self::Color` are separated from other `Self` variants by a semicolon.
         macro_rules! match_code {
-(
+            (
                 $( $color_code:expr => $color:ident ),+ ;
                 $( $format_code:expr => $format:ident ),+ ;
             ) => {

--- a/src/minecraft.rs
+++ b/src/minecraft.rs
@@ -35,6 +35,53 @@ pub enum Format {
     Reset,
 }
 
+impl Format {
+    /// Returns this format's associated [`FormatCode`].
+    ///
+    /// Look up a [`code`][Self::code] against Minecraft Java Edition's list of formatting codes.
+    pub const fn code(self) -> FormatCode {
+        /// Match the input `Self` to a `FormatCode` Value.
+        ///
+        /// Codes that match `Self::Color` are separated from other `Self` variants by a semicolon.
+        macro_rules! match_format {
+            (
+                $( $color:ident => $color_code:literal ),+ ;
+                $( $variant:ident => $format_code:literal ),+ ;
+            ) => {
+                match self {
+                    $( Self::Color(Color::$color) => FormatCode::new($color_code), )+
+                    $( Self::$variant => FormatCode::new($format_code), )+
+                }
+            };
+        }
+
+        match_format! {
+            Black => '0',
+            DarkBlue => '1',
+            DarkGreen => '2',
+            DarkAqua => '3',
+            DarkRed => '4',
+            DarkPurple => '5',
+            Gold => '6',
+            Gray => '7',
+            DarkGray => '8',
+            Blue => '9',
+            Green => 'a',
+            Aqua => 'b',
+            Red => 'c',
+            LightPurple => 'd',
+            Yellow => 'e',
+            White => 'f';
+            Obfuscated => 'k',
+            Bold => 'l',
+            Strikethrough => 'm',
+            Underline => 'n',
+            Italic => 'o',
+            Reset => 'r';
+        }
+    }
+}
+
 impl TryFrom<char> for Format {
     type Error = Error;
 
@@ -52,7 +99,7 @@ impl TryFrom<FormatCode> for Format {
         ///
         /// Codes that match `Self::Color` are separated from other `Self` variants by a semicolon.
         macro_rules! match_code {
-            (
+(
                 $( $color_code:expr => $color:ident ),+ ;
                 $( $format_code:expr => $format:ident ),+ ;
             ) => {
@@ -177,6 +224,12 @@ impl FormatCode {
     /// Returns the inner character.
     pub const fn get(self) -> char {
         self.0
+    }
+}
+
+impl From<Format> for FormatCode {
+    fn from(value: Format) -> Self {
+        value.code()
     }
 }
 

--- a/src/minecraft.rs
+++ b/src/minecraft.rs
@@ -147,9 +147,7 @@ impl FromStr for Format {
     ///
     /// Ex. The `0` in `§0`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let code = get_code(s).ok_or(Error::InvalidFormatCodeString(s.to_string()))?;
-
-        Self::try_from(code)
+        Self::try_from(FormatCode::from_str(s)?)
     }
 }
 
@@ -239,19 +237,25 @@ impl From<char> for FormatCode {
     }
 }
 
+impl FromStr for FormatCode {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        if !(string.starts_with('§') && string.chars().count() == 2) {
+            return Err(Error::InvalidFormatCodeString(string.to_string()));
+        }
+
+        string.chars().nth(1).map(Self::new).ok_or_else(|| {
+            // Panic: We just asserted that `string` contains exactly 2 characters.
+            unreachable!("the input string should always contain two characters")
+        })
+    }
+}
+
 impl Display for FormatCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "§{}", self.get())
     }
-}
-
-/// Get the character following the `§` in a Minecraft format code.
-///
-/// Expects a two character string that starts with `§`.
-///
-/// Ex. The `0` in `§0`.
-pub fn get_code(str: &str) -> Option<FormatCode> {
-    str.chars().nth(1).map(FormatCode) // Take the code, skipping the `§`.
 }
 
 /// Represents a color as it is used for text formatting in Minecraft.


### PR DESCRIPTION
- Converted `FormatCode` from a type alias into a newtype struct, making it easier to add associated functions and trait implementations in the future.
- Added a `Display` implementation for `FormatCode` that includes the special character '§'.
- Added a method to allow `Format` to be converted back into a `FormatCode` (`Format::code`).
- Replaced the `get_code` function with a `FromStr` implementation and added a check for invalid string lengths.

I think that this could be improved by refactoring the two macros that convert to and from the `Format` and `FormatCode` types, since they use the same parameters just in different orders. I'm hesitant to make too big of a change though as I don't want to refactor more than I already have without review or any sort of go-ahead.